### PR TITLE
Update ECS task definition

### DIFF
--- a/.github/workflows/.aws/task-definition.json
+++ b/.github/workflows/.aws/task-definition.json
@@ -30,10 +30,10 @@
                     "CMD-SHELL",
                     "curl -f http://localhost/ || exit 1"
                 ],
-                "interval": 5,
+                "interval": 30,
                 "timeout": 5,
                 "retries": 3,
-                "startPeriod": 60
+                "startPeriod": 120
             }
         },
         {
@@ -72,5 +72,5 @@
         "FARGATE"
     ],
     "cpu": "512",
-    "memory": "1024"
+    "memory": "2048"
 }


### PR DESCRIPTION
The dashboard container takes more memory to build and longer to start up now that we've got more code and more dependencies. This PR adds a longer grace period for the nginx container health check and Increases the dashboard container's memory from 1 to 2 GB.