### PR TITLE
Make sure NGINX uses GZIP for most responses.

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -14,6 +14,9 @@ server {
     index index.html;
 
     gzip on;
+    gzip_vary on;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/html text/css text/javascript application/json application/octet-stream;
 
     location / {
         try_files $uri $uri/ /index.html =404;


### PR DESCRIPTION
Reduces the transfer size of SA_dashboard.geojson from 8ish MB to 2ish MB.