### PR TITLE
Fix ComparisonMenu bouncing on page scroll: make the popper position "fixed"

### DIFF
--- a/frontend/src/components/ComparisonMenu/ComparisonMenu.js
+++ b/frontend/src/components/ComparisonMenu/ComparisonMenu.js
@@ -71,6 +71,7 @@ function ComparisonMenu({
       open={open}
       anchorEl={compareBtnRef?.current}
       placement={'bottom-end'}
+      popperOptions={{ strategy: 'fixed' }}
       modifiers={[
         {
           name: 'offset',


### PR DESCRIPTION
Resolves #281 